### PR TITLE
changed data type for video length representation from double to float

### DIFF
--- a/src/main/java/com/dayquest/dayquestbackend/video/models/Video.java
+++ b/src/main/java/com/dayquest/dayquestbackend/video/models/Video.java
@@ -27,7 +27,7 @@ public class Video {
     private int downVotes;
     private int views;
     private Status status;
-    private double length;
+    private float length;
 
     private int comments;
 
@@ -167,7 +167,7 @@ public class Video {
         return length;
     }
 
-    public void setLength(double length) {
+    public void setLength(float length) {
         this.length = length;
     }
 


### PR DESCRIPTION
as no video on planet earth has enough frames/second to have to use a double for its time representation. (Memory efficiency improved)